### PR TITLE
fixed problem with writing/reading permission of .app/

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -20,6 +20,9 @@ if [ "$(id -u)" = "0" ]; then
     
     # Fix ownership of mounted volumes
     chown -R ${USER_NAME}:${USER_NAME} /home/${USER_NAME} 2>/dev/null || true
+
+    # Ensure all of /app is owned by the target user
+    chown -R ${USER_NAME}:${USER_NAME} /app 2>/dev/null || true
     
     # Switch to user and execute command
     exec gosu ${USER_NAME} "${@:-hatchling}"


### PR DESCRIPTION
Hello Eliott!

Here is my small adjustment so I avoid getting the permission error when starting NeKo. 
Just to recap: upon NeKo initialization, one of its dependencies, Pypath, creates a log folder where is stores the logfiles, useful for debugging purpose. This folder is creates in app, which by default is not accessible. With this PR I am adding to the entrypoint.sh the right to write/read in the whole app folder.

please let me know if this fix make sense!

Keep up with the good work!

Marco