### PR TITLE
Feat/enhance llm provider modularity

### DIFF
--- a/hatchling/core/chat/message_history.py
+++ b/hatchling/core/chat/message_history.py
@@ -10,8 +10,7 @@ from hatchling.core.llm.providers.registry import ProviderRegistry
 from hatchling.core.llm.event_system import EventSubscriber, Event, EventType
 from hatchling.config.llm_settings import ELLMProvider
 
-from hatchling.core.llm.data_structures import ToolCallParsedResult
-from hatchling.mcp_utils.mcp_tool_execution import ToolCallExecutionResult
+from hatchling.core.llm.data_structures import ToolCallParsedResult, ToolCallExecutionResult
 
 class MessageHistory(EventSubscriber):
     """Event-driven message history manager with canonical and provider-specific histories.

--- a/hatchling/core/llm/data_structures.py
+++ b/hatchling/core/llm/data_structures.py
@@ -26,25 +26,3 @@ class ToolCallParsedResult:
             "function_name": self.function_name,
             "arguments": self.arguments
         }
-    
-    def to_ollama_dict(self) -> Dict[str, Any]:
-        """Convert the parse result to Ollama format."""
-        return {
-            "type": "function",
-            "id": self.tool_call_id,
-            "function": {
-                "name": self.function_name,
-                "arguments": self.arguments
-            }
-        }
-    
-    def to_openai_dict(self) -> Dict[str, Any]:
-        """Convert the parse result to OpenAI format."""
-        return {
-            "type": "function",
-            "id": self.tool_call_id,
-            "function": {
-                "name": self.function_name,
-                "arguments": json.dumps(self.arguments)
-            }
-        }

--- a/hatchling/core/llm/data_structures.py
+++ b/hatchling/core/llm/data_structures.py
@@ -4,9 +4,8 @@ This module contains common data structures used across the LLM system
 to avoid circular import dependencies.
 """
 
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 from dataclasses import dataclass
-import json
 
 # TODO: Standardize of dataclasses usage. Where to put them?
 # What to name them? Do we keep them as dataclasses or up to pydantic?
@@ -25,4 +24,38 @@ class ToolCallParsedResult:
             "tool_call_id": self.tool_call_id,
             "function_name": self.function_name,
             "arguments": self.arguments
+        }
+    
+
+@dataclass
+class ToolCallExecutionResult:
+    """Data class to hold the result of a tool call execution."""
+    tool_call_id: str
+    function_name: str
+    arguments: Dict[str, Any]
+    result: Any
+    error: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert the result to a dictionary."""
+        return {
+            "tool_call_id": self.tool_call_id,
+            "function_name": self.function_name,
+            "arguments": self.arguments,
+            "result": self.result,
+            "error": self.error
+        }
+    
+    def to_openai_dict(self) -> Dict[str, Any]:
+        """Convert the result to a dictionary suitable for OpenAI API."""
+        return {
+            "tool_call_id": self.tool_call_id,
+            "content": str(self.result.content[0].text) if self.result.content[0].text else "No result",
+        }
+
+    def to_ollama_dict(self) -> Dict[str, Any]:
+        """Convert the result to a dictionary suitable for Ollama API."""
+        return {
+            "content": str(self.result.content[0].text) if self.result.content[0].text else "No result",
+            "tool_name": self.function_name
         }

--- a/hatchling/core/llm/data_structures.py
+++ b/hatchling/core/llm/data_structures.py
@@ -45,17 +45,3 @@ class ToolCallExecutionResult:
             "result": self.result,
             "error": self.error
         }
-    
-    def to_openai_dict(self) -> Dict[str, Any]:
-        """Convert the result to a dictionary suitable for OpenAI API."""
-        return {
-            "tool_call_id": self.tool_call_id,
-            "content": str(self.result.content[0].text) if self.result.content[0].text else "No result",
-        }
-
-    def to_ollama_dict(self) -> Dict[str, Any]:
-        """Convert the result to a dictionary suitable for Ollama API."""
-        return {
-            "content": str(self.result.content[0].text) if self.result.content[0].text else "No result",
-            "tool_name": self.function_name
-        }

--- a/hatchling/core/llm/providers/base.py
+++ b/hatchling/core/llm/providers/base.py
@@ -187,6 +187,18 @@ class LLMProvider(ABC):
         pass
 
     @abstractmethod
+    def hatchling_to_llm_tool_call(self, tool_call: ToolCallParsedResult) -> Dict[str, Any]:
+        """Convert a Hatchling tool call to LLM provider-specific format.
+
+        Args:
+            tool_call (ToolCallParsedResult): The Hatchling tool call to convert.
+
+        Returns:
+            Dict[str, Any]: LLM provider-specific representation of the tool call.
+        """
+        pass
+
+    @abstractmethod
     def mcp_to_provider_tool(self, tool_info: MCPToolInfo) -> Dict[str, Any]:
         """Convert an MCP tool to provider-specific format.
 

--- a/hatchling/core/llm/providers/base.py
+++ b/hatchling/core/llm/providers/base.py
@@ -168,7 +168,7 @@ class LLMProvider(ABC):
         pass
 
     @abstractmethod
-    def parse_tool_call(self, event: Event) -> Optional[ToolCallParsedResult]:
+    def llm_to_hatchling_tool_call(self, event: Event) -> Optional[ToolCallParsedResult]:
         """Parse a tool call coming from the LLM provider.
 
         This operates a translation "LLM-provider-style tool call" -> "Hatchling-style tool call"

--- a/hatchling/core/llm/providers/base.py
+++ b/hatchling/core/llm/providers/base.py
@@ -169,10 +169,13 @@ class LLMProvider(ABC):
 
     @abstractmethod
     def parse_tool_call(self, event: Event) -> Optional[ToolCallParsedResult]:
-        """Parse a tool call event into a standardized format.
+        """Parse a tool call coming from the LLM provider.
+
+        This operates a translation "LLM-provider-style tool call" -> "Hatchling-style tool call"
+        The event is very likely raised from `_parse_and_publish_chunk`.
 
         Args:
-            event (Event): The raw tool call event from the LLM provider.
+            event (Event): The Hatchling event typed LLM_TOOL_CALL_REQUEST.
 
         Returns:
             Optional[ToolCallParsedResult]: Normalized representation of the tool call, 
@@ -184,16 +187,19 @@ class LLMProvider(ABC):
         pass
 
     @abstractmethod
-    def convert_tool(self, tool_info: MCPToolInfo) -> Dict[str, Any]:
+    def mcp_to_provider_tool(self, tool_info: MCPToolInfo) -> Dict[str, Any]:
         """Convert an MCP tool to provider-specific format.
 
+        Effectively assigns the `provider_format` field of the tool_info to the converted
+        tool format after reading relevant fields such as the name, the description, and
+        the parameters, etc... anything useful for the target provider format.
+
         Args:
-            tool_info (MCPToolInfo): MCP tool information to convert. This is expected
-                                   to be an in/out parameter whose provider_format 
-                                   field will be set to the converted tool format.
+            tool_info (MCPToolInfo): MCP tool information to convert. This is an in/out
+            parameter whose `provider_format` field will be set to the converted tool format.
 
         Returns:
-            Dict[str, Any]: Tool in provider-specific format.
+            Dict[str, Any]: Tool with `provider_format` field assigned.
 
         Raises:
             Exception: If tool conversion fails.

--- a/hatchling/core/llm/providers/base.py
+++ b/hatchling/core/llm/providers/base.py
@@ -11,7 +11,7 @@ from typing import Dict, List, Any, Optional
 from hatchling.core.llm.event_system import EventPublisher
 from hatchling.mcp_utils.mcp_tool_lifecycle_subscriber import ToolLifecycleSubscriber
 from hatchling.core.llm.event_system.event_data import Event
-from hatchling.core.llm.data_structures import ToolCallParsedResult
+from hatchling.core.llm.data_structures import ToolCallParsedResult, ToolCallExecutionResult
 from hatchling.config.settings import AppSettings
 from hatchling.mcp_utils.mcp_tool_data import MCPToolInfo
 
@@ -215,5 +215,17 @@ class LLMProvider(ABC):
 
         Raises:
             Exception: If tool conversion fails.
+        """
+        pass
+
+    @abstractmethod
+    def hatchling_to_provider_tool_result(self, tool_result: ToolCallExecutionResult) -> Dict[str, Any]:
+        """Convert a Hatchling tool result to LLM provider-specific format.
+
+        Args:
+            tool_result (ToolCallExecutionResult): The Hatchling tool result to convert.
+
+        Returns:
+            Dict[str, Any]: LLM provider-specific representation of the tool result.
         """
         pass

--- a/hatchling/core/llm/providers/ollama_provider.py
+++ b/hatchling/core/llm/providers/ollama_provider.py
@@ -367,7 +367,7 @@ class OllamaProvider(LLMProvider):
                 "message": f"Ollama server unavailable: {str(e)}"
             }
 
-    def parse_tool_call(self, event: Event) -> Optional[ToolCallParsedResult]:
+    def llm_to_hatchling_tool_call(self, event: Event) -> Optional[ToolCallParsedResult]:
         """Parse an Ollama tool call event.
 
         Args:
@@ -387,7 +387,7 @@ class OllamaProvider(LLMProvider):
             if not tool_calls:
                 raise ValueError("No tool calls found in Ollama event")
                 
-            # Process the first tool call (if multiple, we'd need to call parse_tool_call for each)
+            # Process the first tool call (if multiple, we'd need to call llm_to_hatchling_tool_call for each)
             tool_call = tool_calls[0]
             
             # Extract standard fields

--- a/hatchling/core/llm/providers/ollama_provider.py
+++ b/hatchling/core/llm/providers/ollama_provider.py
@@ -76,7 +76,7 @@ class OllamaProvider(LLMProvider):
         """
         try:
             self._client = AsyncClient(host=self._settings.ollama.api_base)
-            self._toolLifecycle_subscriber = ToolLifecycleSubscriber(ELLMProvider.OLLAMA.value, self.convert_tool)
+            self._toolLifecycle_subscriber = ToolLifecycleSubscriber(ELLMProvider.OLLAMA.value, self.mcp_to_provider_tool)
             self._event_publisher = EventPublisher()
             mcp_manager.publisher.subscribe(self._toolLifecycle_subscriber)
             
@@ -413,7 +413,7 @@ class OllamaProvider(LLMProvider):
             logger.error(f"Error parsing Ollama tool call: {e}")
             raise ValueError(f"Failed to parse Ollama tool call: {e}")
 
-    def convert_tool(self, tool_info: MCPToolInfo) -> Dict[str, Any]:
+    def mcp_to_provider_tool(self, tool_info: MCPToolInfo) -> Dict[str, Any]:
         """Convert an MCP tool to Ollama function format.
 
         Args:

--- a/hatchling/core/llm/providers/ollama_provider.py
+++ b/hatchling/core/llm/providers/ollama_provider.py
@@ -19,7 +19,7 @@ from hatchling.core.llm.event_system.event_publisher import EventPublisher
 from hatchling.core.llm.event_system.event_data import EventType
 from hatchling.core.llm.event_system.event_subscribers_examples import Event
 from hatchling.mcp_utils.mcp_tool_lifecycle_subscriber import ToolLifecycleSubscriber
-from hatchling.core.llm.data_structures import ToolCallParsedResult
+from hatchling.core.llm.data_structures import ToolCallParsedResult, ToolCallExecutionResult
 from hatchling.mcp_utils.manager import mcp_manager
 
 logger = logging.getLogger(__name__)
@@ -462,3 +462,18 @@ class OllamaProvider(LLMProvider):
         except Exception as e:
             logger.error(f"Failed to convert tool {tool_info.name} to Ollama format: {e}")
             return {}
+    
+    def hatchling_to_provider_tool_result(self, tool_result: ToolCallExecutionResult) -> Dict[str, Any]:
+        """Convert the result to a dictionary suitable for Ollama API.
+
+        Args:
+            tool_result (ToolCallExecutionResult): The tool call execution result.
+
+        Returns:
+            Dict[str, Any]: The result in Ollama format.
+        """
+
+        return {
+            "content": str(tool_result.result.content[0].text) if tool_result.result.content[0].text else "No result",
+            "tool_name": tool_result.function_name
+        }

--- a/hatchling/core/llm/providers/ollama_provider.py
+++ b/hatchling/core/llm/providers/ollama_provider.py
@@ -412,6 +412,24 @@ class OllamaProvider(LLMProvider):
         except Exception as e:
             logger.error(f"Error parsing Ollama tool call: {e}")
             raise ValueError(f"Failed to parse Ollama tool call: {e}")
+        
+    def hatchling_to_llm_tool_call(self, tool_call: ToolCallParsedResult) -> Dict[str, Any]:
+        """Convert an LLM tool call parsing result back to the Ollama format.
+
+        Args:
+            tool_call (ToolCallParsedResult): The parsed tool call result.
+
+        Returns:
+            Dict[str, Any]: The tool call in Ollama format.
+        """
+        return {
+            "type": "function",
+            "id": tool_call.tool_call_id,
+            "function": {
+                "name": tool_call.function_name,
+                "arguments": tool_call.arguments
+            }
+        }
 
     def mcp_to_provider_tool(self, tool_info: MCPToolInfo) -> Dict[str, Any]:
         """Convert an MCP tool to Ollama function format.

--- a/hatchling/core/llm/providers/openai_provider.py
+++ b/hatchling/core/llm/providers/openai_provider.py
@@ -476,6 +476,24 @@ class OpenAIProvider(LLMProvider):
         except json.JSONDecodeError:
             logger.warning(f"Failed to parse OpenAI tool call arguments: {args_str}")
             return {"_raw": args_str}
+        
+    def hatchling_to_llm_tool_call(self, tool_call: ToolCallParsedResult) -> Dict[str, Any]:
+        """Convert a Hatchling tool call parsing result back to the OpenAI format.
+
+        Args:
+            tool_call (ToolCallParsedResult): The parsed tool call result.
+
+        Returns:
+            Dict[str, Any]: The tool call in OpenAI format.
+        """
+        return {
+            "type": "function",
+            "id": tool_call.tool_call_id,
+            "function": {
+                "name": tool_call.function_name,
+                "arguments": json.dumps(tool_call.arguments)
+            }
+        }
 
     def mcp_to_provider_tool(self, tool_info: MCPToolInfo) -> Dict[str, Any]:
         """Convert an MCP tool to OpenAI function format.

--- a/hatchling/core/llm/providers/openai_provider.py
+++ b/hatchling/core/llm/providers/openai_provider.py
@@ -97,7 +97,7 @@ class OpenAIProvider(LLMProvider):
             self._client = AsyncOpenAI(**client_kwargs, http_client=self._http_client)
 
             self._event_publisher = EventPublisher()
-            self._toolLifecycle_subscriber = ToolLifecycleSubscriber(self._settings.llm.provider_name, self.convert_tool)
+            self._toolLifecycle_subscriber = ToolLifecycleSubscriber(self._settings.llm.provider_name, self.mcp_to_provider_tool)
             mcp_manager.publisher.subscribe(self._toolLifecycle_subscriber)
 
             logger.info("Successfully connected to OpenAI API")
@@ -477,7 +477,7 @@ class OpenAIProvider(LLMProvider):
             logger.warning(f"Failed to parse OpenAI tool call arguments: {args_str}")
             return {"_raw": args_str}
 
-    def convert_tool(self, tool_info: MCPToolInfo) -> Dict[str, Any]:
+    def mcp_to_provider_tool(self, tool_info: MCPToolInfo) -> Dict[str, Any]:
         """Convert an MCP tool to OpenAI function format.
         
         Args:

--- a/hatchling/core/llm/providers/openai_provider.py
+++ b/hatchling/core/llm/providers/openai_provider.py
@@ -417,7 +417,7 @@ class OpenAIProvider(LLMProvider):
                 "message": f"OpenAI API unavailable: {str(e)}"
             }
 
-    def parse_tool_call(self, event: Event) -> Optional[ToolCallParsedResult]:
+    def llm_to_hatchling_tool_call(self, event: Event) -> Optional[ToolCallParsedResult]:
         """Parse an OpenAI tool call event.
 
         Args:
@@ -441,7 +441,7 @@ class OpenAIProvider(LLMProvider):
                 return ToolCallParsedResult(
                     tool_call_id="function_call",
                     function_name=function_call.get("name", ""),
-                    arguments=self._parse_tool_call_arguments(function_call.get("arguments", "{}"))
+                    arguments=self._llm_to_hatchling_tool_call_arguments(function_call.get("arguments", "{}"))
                 )
             
             # Handle modern tool_call format (single complete tool call)
@@ -450,7 +450,7 @@ class OpenAIProvider(LLMProvider):
                 return ToolCallParsedResult(
                     tool_call_id=tool_call.get("id", "unknown"),
                     function_name=tool_call.get("function", {}).get("name", ""),
-                    arguments=self._parse_tool_call_arguments(tool_call.get("function", {}).get("arguments", "{}"))
+                    arguments=self._llm_to_hatchling_tool_call_arguments(tool_call.get("function", {}).get("arguments", "{}"))
                 )
             
             raise ValueError("No valid tool call data found in OpenAI event")
@@ -459,7 +459,7 @@ class OpenAIProvider(LLMProvider):
             logger.error(f"Error parsing OpenAI tool call: {e}")
             raise ValueError(f"Failed to parse OpenAI tool call: {e}")
 
-    def _parse_tool_call_arguments(self, args_str: str) -> Dict[str, Any]:
+    def _llm_to_hatchling_tool_call_arguments(self, args_str: str) -> Dict[str, Any]:
         """Parse tool call arguments from JSON string to dictionary.
         
         Args:

--- a/hatchling/core/llm/providers/openai_provider.py
+++ b/hatchling/core/llm/providers/openai_provider.py
@@ -21,7 +21,7 @@ from hatchling.mcp_utils.mcp_tool_data import MCPToolInfo
 from hatchling.core.llm.event_system import EventPublisher, EventType
 from hatchling.mcp_utils.mcp_tool_lifecycle_subscriber import ToolLifecycleSubscriber
 from hatchling.core.llm.event_system.event_subscribers_examples import Event
-from hatchling.core.llm.data_structures import ToolCallParsedResult
+from hatchling.core.llm.data_structures import ToolCallParsedResult, ToolCallExecutionResult
 
 logger = logging.getLogger(__name__)
 
@@ -525,3 +525,17 @@ class OpenAIProvider(LLMProvider):
         except Exception as e:
             logger.error(f"Failed to convert tool {tool_info.name} to OpenAI format: {e}")
             return {}
+
+    def hatchling_to_provider_tool_result(self, tool_result: ToolCallExecutionResult) -> Dict[str, Any]:
+        """Convert a Hatchling tool call execution result to the OpenAI format.
+
+        Args:
+            tool_result (ToolCallExecutionResult): The tool call execution result.
+
+        Returns:
+            Dict[str, Any]: The result in OpenAI format.
+        """
+        return {
+            "content": str(tool_result.result.content[0].text) if tool_result.result.content[0].text else "No result",
+            "tool_name": tool_result.function_name
+        }

--- a/hatchling/core/llm/tool_management/tool_chaining_subscriber.py
+++ b/hatchling/core/llm/tool_management/tool_chaining_subscriber.py
@@ -15,9 +15,8 @@ from hatchling.core.llm.providers import ProviderRegistry
 from hatchling.core.llm.event_system.event_subscriber import EventSubscriber
 from hatchling.core.llm.event_system.event_data import EventType, Event
 from hatchling.core.llm.event_system.event_publisher import EventPublisher
-from hatchling.core.llm.data_structures import ToolCallParsedResult
+from hatchling.core.llm.data_structures import ToolCallParsedResult, ToolCallExecutionResult
 from hatchling.core.llm.tool_management.tool_result_collector_subscriber import ToolResultCollectorSubscriber
-from hatchling.mcp_utils.mcp_tool_execution import ToolCallExecutionResult
 from hatchling.core.chat.message_history_registry import MessageHistoryRegistry
 from hatchling.core.logging.logging_manager import logging_manager
 from hatchling.mcp_utils.mcp_tool_execution import MCPToolExecution

--- a/hatchling/core/llm/tool_management/tool_result_collector_subscriber.py
+++ b/hatchling/core/llm/tool_management/tool_result_collector_subscriber.py
@@ -13,8 +13,7 @@ from hatchling.core.logging.logging_manager import logging_manager
 from hatchling.core.llm.event_system.event_subscriber import EventSubscriber
 from hatchling.core.llm.event_system.event_data import Event, EventType
 
-from hatchling.core.llm.data_structures import ToolCallParsedResult
-from hatchling.mcp_utils.mcp_tool_execution import ToolCallExecutionResult
+from hatchling.core.llm.data_structures import ToolCallParsedResult, ToolCallExecutionResult
 
 @dataclass
 class ToolCallExecutionResultLight:

--- a/hatchling/mcp_utils/mcp_tool_call_subscriber.py
+++ b/hatchling/mcp_utils/mcp_tool_call_subscriber.py
@@ -58,7 +58,7 @@ class MCPToolCallSubscriber(EventSubscriber):
             try:
                 self.logger.debug(f"Received LLM_TOOL_CALL_REQUEST event: {event}")
                 provider = ProviderRegistry.get_provider(event.provider)
-                parsed_tool_call = provider.parse_tool_call(event)
+                parsed_tool_call = provider.llm_to_hatchling_tool_call(event)
             except Exception as e:
                 self.logger.error(f"Error parsing tool call event: {e}")
                 return

--- a/hatchling/mcp_utils/mcp_tool_execution.py
+++ b/hatchling/mcp_utils/mcp_tool_execution.py
@@ -4,52 +4,16 @@ This module provides enhanced functionality for handling tool execution requests
 managing tool calling chains, and processing tool results with event-driven architecture.
 """
 
-import json
 import logging
 import time
 import asyncio
-from typing import List, Dict, Tuple, Any, Optional
-from dataclasses import dataclass
 from mcp.types import CallToolResult
 
 from hatchling.mcp_utils.manager import mcp_manager
 from hatchling.core.logging.logging_manager import logging_manager
 from hatchling.config.settings import AppSettings
 from hatchling.core.llm.event_system import EventPublisher, EventType
-from hatchling.core.llm.data_structures import ToolCallParsedResult
-
-@dataclass
-class ToolCallExecutionResult:
-    """Data class to hold the result of a tool call execution."""
-    tool_call_id: str
-    function_name: str
-    arguments: Dict[str, Any]
-    result: Any
-    error: Optional[str] = None
-
-    def to_dict(self) -> Dict[str, Any]:
-        """Convert the result to a dictionary."""
-        return {
-            "tool_call_id": self.tool_call_id,
-            "function_name": self.function_name,
-            "arguments": self.arguments,
-            "result": self.result,
-            "error": self.error
-        }
-    
-    def to_openai_dict(self) -> Dict[str, Any]:
-        """Convert the result to a dictionary suitable for OpenAI API."""
-        return {
-            "tool_call_id": self.tool_call_id,
-            "content": str(self.result.content[0].text) if self.result.content[0].text else "No result",
-        }
-
-    def to_ollama_dict(self) -> Dict[str, Any]:
-        """Convert the result to a dictionary suitable for Ollama API."""
-        return {
-            "content": str(self.result.content[0].text) if self.result.content[0].text else "No result",
-            "tool_name": self.function_name
-        }
+from hatchling.core.llm.data_structures import ToolCallParsedResult, ToolCallExecutionResult
 
 class MCPToolExecution:
     """Manages tool execution and tool calling chains with event publishing."""

--- a/hatchling/mcp_utils/mcp_tool_lifecycle_subscriber.py
+++ b/hatchling/mcp_utils/mcp_tool_lifecycle_subscriber.py
@@ -15,16 +15,16 @@ class ToolLifecycleSubscriber(EventSubscriber):
     to get enabled tools for use in LLM payloads.
     """
     
-    def __init__(self, provider_name: str, convert_tool_func: Callable[[MCPToolInfo], Dict[str, Any]]):
+    def __init__(self, provider_name: str, mcp_to_provider_tool_func: Callable[[MCPToolInfo], Dict[str, Any]]):
         """Initialize the tool lifecycle subscriber.
         
         Args:
             provider_name (str): Name of the LLM provider using this subscriber.
-            convert_tool_func (Callable): Function to convert MCP tools to provider-specific format.
+            mcp_to_provider_tool_func (Callable): Function to convert MCP tools to provider-specific format.
         """
         self.provider_name = provider_name
         self._tool_cache: Dict[str, MCPToolInfo] = {}
-        self._convert_tool_func = convert_tool_func
+        self._mcp_to_provider_tool_func = mcp_to_provider_tool_func
         self.logger = logging.getLogger(f"{self.__class__.__name__}[{provider_name}]")
     
     def on_event(self, event: Event) -> None:
@@ -131,10 +131,10 @@ class ToolLifecycleSubscriber(EventSubscriber):
                 return
             
             # Convert tool to provider-specific format
-            # Tool info is an in/out parameter in convert_tool
+            # Tool info is an in/out parameter in mcp_to_provider_tool
             # Hence, the provider_format field will be set
             # to the converted tool format
-            self._convert_tool_func(tool_info)
+            self._mcp_to_provider_tool_func(tool_info)
 
             self._tool_cache[tool_name] = tool_info
             self.logger.debug(f"Tool enabled: {tool_name}")

--- a/hatchling/ui/cli_event_subscriber.py
+++ b/hatchling/ui/cli_event_subscriber.py
@@ -292,7 +292,7 @@ class CLIEventSubscriber(EventSubscriber):
         data = event.data
         # Set tool is running
         provider = ProviderRegistry.get_provider(event.provider)
-        parsed_tool_call = provider.parse_tool_call(event)
+        parsed_tool_call = provider.llm_to_hatchling_tool_call(event)
         self._set_info(
             f"[{parsed_tool_call.tool_call_id}]\n" +
             f"Tool call to {parsed_tool_call.function_name} requested with parameters:\n" +

--- a/tests/feature_test_llm_provider_base.py
+++ b/tests/feature_test_llm_provider_base.py
@@ -104,8 +104,8 @@ class TestLLMProviderBase(unittest.TestCase):
                     arguments={}
                 )
             
-            def convert_tool(self, tool_info):
-                """Mock implementation of convert_tool."""
+            def mcp_to_provider_tool(self, tool_info):
+                """Mock implementation of mcp_to_provider_tool."""
                 return {"type": "function", "function": {"name": tool_info.name}}
         
         # Should be able to instantiate concrete implementation
@@ -161,8 +161,8 @@ class TestLLMProviderBase(unittest.TestCase):
                     arguments={}
                 )
             
-            def convert_tool(self, tool_info):
-                """Mock implementation of convert_tool."""
+            def mcp_to_provider_tool(self, tool_info):
+                """Mock implementation of mcp_to_provider_tool."""
                 return {"type": "function", "function": {"name": tool_info.name}}
 
         provider = OllamaProvider({})

--- a/tests/feature_test_llm_provider_base.py
+++ b/tests/feature_test_llm_provider_base.py
@@ -95,8 +95,8 @@ class TestLLMProviderBase(unittest.TestCase):
             async def check_health(self):
                 return {"available": True, "message": "OK"}
             
-            def parse_tool_call(self, event):
-                """Mock implementation of parse_tool_call."""
+            def llm_to_hatchling_tool_call(self, event):
+                """Mock implementation of llm_to_hatchling_tool_call."""
                 from hatchling.core.llm.data_structures import ToolCallParsedResult
                 return ToolCallParsedResult(
                     tool_call_id="test_id",
@@ -152,8 +152,8 @@ class TestLLMProviderBase(unittest.TestCase):
             async def check_health(self):
                 return {"available": True, "message": "OK"}
             
-            def parse_tool_call(self, event):
-                """Mock implementation of parse_tool_call."""
+            def llm_to_hatchling_tool_call(self, event):
+                """Mock implementation of llm_to_hatchling_tool_call."""
                 from hatchling.core.llm.data_structures import ToolCallParsedResult
                 return ToolCallParsedResult(
                     tool_call_id="test_id",

--- a/tests/feature_test_mcp_tool_call_subscriber.py
+++ b/tests/feature_test_mcp_tool_call_subscriber.py
@@ -61,7 +61,7 @@ class TestMCPToolCallSubscriberRegistry(unittest.TestCase):
 
         # Use provider to get the strategy
         provider = ProviderRegistry.get_provider(ELLMProvider.OLLAMA)
-        parsed_tool_call = provider.parse_tool_call(ollama_event)
+        parsed_tool_call = provider.llm_to_hatchling_tool_call(ollama_event)
         
         subscriber = MCPToolCallSubscriber(self.mock_tool_execution)
         subscriber.on_event(ollama_event)

--- a/tests/feature_test_provider_registry.py
+++ b/tests/feature_test_provider_registry.py
@@ -71,8 +71,8 @@ def create_test_provider_class(name="test"):
                 arguments={}
             )
         
-        def convert_tool(self, tool_info):
-            """Mock implementation of convert_tool."""
+        def mcp_to_provider_tool(self, tool_info):
+            """Mock implementation of mcp_to_provider_tool."""
             return {"type": "function", "function": {"name": tool_info.name}}
     
     return TestProvider

--- a/tests/feature_test_provider_registry.py
+++ b/tests/feature_test_provider_registry.py
@@ -62,8 +62,8 @@ def create_test_provider_class(name="test"):
         async def check_health(self):
             return {"available": True, "message": f"{name} OK"}
         
-        def parse_tool_call(self, event):
-            """Mock implementation of parse_tool_call."""
+        def llm_to_hatchling_tool_call(self, event):
+            """Mock implementation of llm_to_hatchling_tool_call."""
             from hatchling.core.llm.data_structures import ToolCallParsedResult
             return ToolCallParsedResult(
                 tool_call_id="test_id",

--- a/tests/integration_test_ollama.py
+++ b/tests/integration_test_ollama.py
@@ -163,8 +163,8 @@ class TestOllamaProviderSync(unittest.TestCase):
     def test_tool_lifecycle_subscriber_cache(self):
         """Test ToolLifecycleSubscriber cache and event handling in isolation."""
         
-        # Create a mock convert_tool function
-        def mock_convert_tool(tool_info):
+        # Create a mock mcp_to_provider_tool function
+        def mock_mcp_to_provider_tool(tool_info):
             provider_format = {
                 "type": "function",
                 "function": {
@@ -177,7 +177,7 @@ class TestOllamaProviderSync(unittest.TestCase):
             tool_info.provider_format = provider_format
             return provider_format
         
-        tls = ToolLifecycleSubscriber("ollama", mock_convert_tool)
+        tls = ToolLifecycleSubscriber("ollama", mock_mcp_to_provider_tool)
         publisher = EventPublisher()
         publisher.subscribe(tls)
 


### PR DESCRIPTION
This pull request refactors how Hatchling translates tool calls and tool results between its internal format and provider-specific formats (OpenAI, Ollama, etc.). The logic is now centralized inside the `LLMProvider` abstraction instead of scattered as methods of the data classes. This makes it easier to add support for new providers and maintain consistent formatting across the codebase.

**Provider-driven translation and extensibility:**
* Added new abstract methods to `BaseProvider` for converting between Hatchling and provider formats: `llm_to_hatchling_tool_call`, `hatchling_to_llm_tool_call`, `mcp_to_provider_tool`, and `hatchling_to_provider_tool_result`. Updated existing provider implementations (OpenAI, Ollama) to use these methods. [[1]](diffhunk://#diff-489843da86cdb3e47edca54bc185bd0ea4bd9dce4f9d7355164766172bd9cfccL171-R178) [[2]](diffhunk://#diff-489843da86cdb3e47edca54bc185bd0ea4bd9dce4f9d7355164766172bd9cfccL187-R231) [[3]](diffhunk://#diff-5514368aa7ed5086cd73b05f22ee8761311c4c7f21a581fa01e502d78c345812L370-R370) [[4]](diffhunk://#diff-5514368aa7ed5086cd73b05f22ee8761311c4c7f21a581fa01e502d78c345812L416-R434) [[5]](diffhunk://#diff-5514368aa7ed5086cd73b05f22ee8761311c4c7f21a581fa01e502d78c345812R465-R479) [[6]](diffhunk://#diff-5a0ccf2ac3ffb3accd2ad5a1c9e67d9599cb6e5321db04f8dc45f443ec756c7eL420-R420)
* Updated provider initialization to use the new conversion method names, ensuring correct subscription of tool lifecycle events. [[1]](diffhunk://#diff-5514368aa7ed5086cd73b05f22ee8761311c4c7f21a581fa01e502d78c345812L79-R79) [[2]](diffhunk://#diff-5a0ccf2ac3ffb3accd2ad5a1c9e67d9599cb6e5321db04f8dc45f443ec756c7eL100-R100)

**Updated the usage of the old function to new ones via the ProviderRegistry:**

* Replaced hardcoded provider-specific tool call/result formatting in `message_history.py` with calls to `ProviderRegistry`, using new standardized conversion methods (`hatchling_to_llm_tool_call` and `hatchling_to_provider_tool_result`) for both tool calls and results. [[1]](diffhunk://#diff-369a0ad856d50c0db59d8142899b2c38a0d5448b36c5b48a8930aae984c5ee58L135-R138) [[2]](diffhunk://#diff-369a0ad856d50c0db59d8142899b2c38a0d5448b36c5b48a8930aae984c5ee58L166-R163) [[3]](diffhunk://#diff-369a0ad856d50c0db59d8142899b2c38a0d5448b36c5b48a8930aae984c5ee58L196-R189) [[4]](diffhunk://#diff-369a0ad856d50c0db59d8142899b2c38a0d5448b36c5b48a8930aae984c5ee58L221-R217) [[5]](diffhunk://#diff-369a0ad856d50c0db59d8142899b2c38a0d5448b36c5b48a8930aae984c5ee58L298-R292)

These changes make the codebase more maintainable and extensible by centralizing provider-specific logic and reducing duplication.