### PR TITLE
ci: fix pushing new version files to `main`

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -39,11 +39,18 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
     steps:
+      - name: Generate GitHub App Token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.SEMANTIC_RELEASE_APP_ID }}
+          private_key: ${{ secrets.SEMANTIC_RELEASE_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -58,5 +65,5 @@ jobs:
 
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: npx semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,6 @@
 {
   "repositoryUrl": "https://github.com/CrackingShells/Hatchling",
+  "tagFormat": "v${version}",
   "branches": [
     "main",
     {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,13 +209,14 @@ python run_tests.py --only feature,regression
 
 ## Release Process
 
-Releases are fully automated using semantic-release:
+Releases are fully automated using semantic-release with GitHub App integration:
 
 1. **Commits are analyzed** for conventional commit format
 2. **Version is calculated** based on commit types
 3. **Changelog is generated** from commit messages
-4. **GitHub release is created** with release notes
-5. **Version is updated** in pyproject.toml
+4. **Version files are updated** (pyproject.toml, CHANGELOG.md)
+5. **Changes are committed** back to repository using GitHub App
+6. **GitHub release is created** with release notes and tags
 
 ### Version Impact
 


### PR DESCRIPTION
Main being protected against direct pushes, we only authorize a specific github app to do it.