### PR TITLE
chore(issues): add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,139 @@
+name: 🐛 Bug Report
+description: Report a bug or unexpected behavior in Hatchling
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug! Please fill out the information below to help us diagnose and fix the issue.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission checklist
+      description: Please verify these items before submitting
+      options:
+        - label: I have searched existing issues to ensure this is not a duplicate
+          required: true
+        - label: I have checked the [documentation](https://github.com/CrackingShells/Hatchling/tree/main/docs) for relevant information
+          required: true
+        - label: I can reproduce this issue consistently
+          required: true
+
+  - type: dropdown
+    id: bug_category
+    attributes:
+      label: Bug Category
+      description: What type of issue are you experiencing?
+      options:
+        - LLM Provider Connection (Ollama/OpenAI authentication, timeouts)
+        - MCP Server Integration (server connection, tool discovery, execution)
+        - Chat Interface (CLI display, commands, session management)
+        - Tool Calling & Chaining (execution failures, citation issues)
+        - Configuration (settings, environment variables, TOML files)
+        - Performance (slow responses, memory usage, timeouts)
+        - Installation & Setup
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment Information
+      description: Please provide your system and Hatchling environment details
+      placeholder: |
+        - OS: (e.g., Ubuntu 22.04, macOS 14.1, Windows 11)
+        - Hatchling version: (run `version` command in chat)
+        - Python version: 
+        - LLM Provider: (Ollama/OpenAI)
+        - LLM Model: (e.g., llama3.2, gpt-4)
+        - Docker setup: (yes/no, if using Docker)
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is
+      placeholder: Describe what happened and what you expected to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Detailed steps to reproduce the behavior
+      placeholder: |
+        1. Start Hatchling with '...'
+        2. Run command '...'
+        3. Enter message '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen
+      placeholder: A clear description of what you expected to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual Behavior
+      description: What actually happened
+      placeholder: A clear description of what actually happened, including any error messages
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs
+      description: |
+        Please include relevant log output. You can:
+        - Use `show_logs` command in chat to get recent logs
+        - Check the log file at `~/.hatch/logs/hatchling.log`
+        - Use `set_log_level debug` for more detailed logging
+      placeholder: Paste relevant log entries here
+      render: text
+
+  - type: textarea
+    id: configuration
+    attributes:
+      label: Configuration Details
+      description: |
+        If the issue is configuration-related, please share relevant settings:
+        - Settings from `settings:list` command
+        - Content of `~/.hatch/settings/hatchling_settings.toml` (remove sensitive data like API keys)
+        - Environment variables (HATCH_*, OLLAMA_*, OPENAI_*)
+      placeholder: Paste relevant configuration here (remove sensitive information)
+      render: text
+
+  - type: textarea
+    id: mcp_servers
+    attributes:
+      label: MCP Server Information
+      description: |
+        If the issue involves MCP servers, please provide:
+        - Output of `mcp:server:list` command
+        - Output of `mcp:tool:list` command
+        - Any custom MCP servers you've added
+      placeholder: Paste MCP server information here
+      render: text
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem (screenshots, workarounds tried, etc.)
+      placeholder: Add any other context about the problem here

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📚 Documentation
+    url: https://github.com/CrackingShells/Hatchling/tree/main/docs
+    about: Check the documentation for setup guides, tutorials, and troubleshooting
+  - name: 💬 Discussions
+    url: https://github.com/CrackingShells/Hatchling/discussions
+    about: Ask questions, share ideas, or discuss features with the community
+  - name: 🔗 Related Projects
+    url: https://github.com/CrackingShells
+    about: Issues with Hatch package manager, schemas, or registry should be reported in their respective repositories

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,148 @@
+name: 📚 Documentation Issue
+description: Report issues with documentation or request documentation improvements
+title: "[Docs]: "
+labels: ["documentation", "needs-triage"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve our documentation! Please provide details about the documentation issue or improvement.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission checklist
+      description: Please verify these items before submitting
+      options:
+        - label: I have searched existing issues to ensure this is not a duplicate
+          required: true
+        - label: I have checked multiple documentation sources (README, docs/, articles/)
+          required: true
+
+  - type: dropdown
+    id: doc_type
+    attributes:
+      label: Documentation Type
+      description: What type of documentation issue is this?
+      options:
+        - Missing Documentation (feature/command not documented)
+        - Incorrect Information (documentation is wrong or outdated)
+        - Unclear Instructions (confusing or hard to follow)
+        - Broken Links (links don't work or go to wrong place)
+        - Typos/Grammar (spelling, grammar, or formatting issues)
+        - Missing Examples (need more examples or use cases)
+        - Installation/Setup (issues with setup instructions)
+        - API/Command Reference (missing or incorrect command documentation)
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: doc_location
+    attributes:
+      label: Documentation Location
+      description: Where is the documentation issue located?
+      placeholder: |
+        e.g., README.md, docs/articles/users/chat_commands.md, 
+        docs/articles/users/tutorials/Installation/docker-ollama-setup.md
+    validations:
+      required: true
+
+  - type: textarea
+    id: issue_description
+    attributes:
+      label: Issue Description
+      description: Describe the documentation issue in detail
+      placeholder: |
+        Clearly describe what's wrong, missing, or confusing about the documentation.
+        Be specific about what you were trying to accomplish.
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_content
+    attributes:
+      label: Current Content
+      description: |
+        If applicable, quote the current documentation content that has issues
+      placeholder: |
+        Copy and paste the current documentation text that needs to be fixed.
+        Use quotes or code blocks to clearly identify the content.
+      render: markdown
+
+  - type: textarea
+    id: suggested_improvement
+    attributes:
+      label: Suggested Improvement
+      description: How should the documentation be improved?
+      placeholder: |
+        Provide your suggestion for how to fix or improve the documentation.
+        Include specific text changes, additional examples, or structural improvements.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What were you trying to accomplish when you found this issue?
+      placeholder: |
+        Describe your use case or what you were trying to learn/do:
+        - Setting up Hatchling for the first time
+        - Trying to use a specific command
+        - Integrating with a new LLM provider
+        - Creating a custom MCP server
+        - etc.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: user_level
+    attributes:
+      label: User Experience Level
+      description: What's your experience level with Hatchling?
+      options:
+        - New User (first time using Hatchling)
+        - Beginner (basic usage, following tutorials)
+        - Intermediate (comfortable with most features)
+        - Advanced (power user, custom configurations)
+        - Developer (contributing to the project)
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional_examples
+    attributes:
+      label: Additional Examples Needed
+      description: |
+        If requesting examples, what specific scenarios should be covered?
+      placeholder: |
+        Describe what examples would be helpful:
+        - Step-by-step tutorials
+        - Common use cases
+        - Configuration examples
+        - Troubleshooting scenarios
+        - Code samples
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      description: Would you be interested in helping improve this documentation?
+      options:
+        - label: I would be willing to contribute to fixing this documentation
+        - label: I would be willing to review proposed documentation changes
+        - label: I can provide additional examples or use cases
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Any other context about this documentation issue
+      placeholder: |
+        Include any additional information:
+        - Screenshots of confusing interfaces
+        - Links to related documentation
+        - Similar issues in other projects
+        - Urgency or impact of this issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,121 @@
+name: ✨ Feature Request
+description: Suggest a new feature or enhancement for Hatchling
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a new feature! Please provide as much detail as possible to help us understand your request.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission checklist
+      description: Please verify these items before submitting
+      options:
+        - label: I have searched existing issues and discussions to ensure this is not a duplicate
+          required: true
+        - label: I have checked the [roadmap](https://github.com/CrackingShells/Hatchling#roadmap) to see if this is already planned
+          required: true
+
+  - type: dropdown
+    id: feature_category
+    attributes:
+      label: Feature Category
+      description: What area does this feature request relate to?
+      options:
+        - LLM Provider Support (new providers, authentication methods)
+        - Chat Interface (UI improvements, new commands, display features)
+        - MCP Server Management (server discovery, tool management, debugging)
+        - Tool Calling & Chaining (execution improvements, citation features)
+        - Configuration & Settings (new settings, configuration management)
+        - Performance & Optimization
+        - Documentation & Help
+        - Developer Experience
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem_statement
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve? What is the current limitation?
+      placeholder: |
+        Describe the problem or limitation you're experiencing.
+        For example: "Currently, I cannot..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed_solution
+    attributes:
+      label: Proposed Solution
+      description: Describe your ideal solution to this problem
+      placeholder: |
+        Describe what you would like to see implemented.
+        Be as specific as possible about the desired behavior.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_cases
+    attributes:
+      label: Use Cases
+      description: Describe specific scenarios where this feature would be useful
+      placeholder: |
+        Provide concrete examples of how this feature would be used:
+        1. When working with...
+        2. During...
+        3. To accomplish...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What alternatives have you considered? What workarounds are you currently using?
+      placeholder: |
+        Describe any alternative solutions or workarounds you've considered or tried.
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      description: How important is this feature to your workflow?
+      options:
+        - Low - Nice to have
+        - Medium - Would improve my workflow
+        - High - Blocking my work or significantly impacts productivity
+    validations:
+      required: true
+
+  - type: textarea
+    id: implementation_ideas
+    attributes:
+      label: Implementation Ideas
+      description: |
+        Do you have any ideas about how this could be implemented? 
+        (Optional - only if you have technical insights)
+      placeholder: |
+        If you have ideas about implementation approaches, commands, or technical details, share them here.
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or examples that would help explain this feature request
+      placeholder: Add any other context, mockups, or examples here
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      description: Would you be interested in contributing to this feature?
+      options:
+        - label: I would be willing to contribute to implementing this feature
+        - label: I would be willing to help with testing this feature
+        - label: I would be willing to help with documentation for this feature

--- a/.github/ISSUE_TEMPLATE/llm_provider_request.yml
+++ b/.github/ISSUE_TEMPLATE/llm_provider_request.yml
@@ -1,0 +1,185 @@
+name: 🤖 LLM Provider Request
+description: Request support for a new LLM provider
+title: "[LLM Provider]: "
+labels: ["enhancement", "llm-provider", "needs-triage"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for requesting a new LLM provider! Hatchling has a standardized interface for adding LLM providers. 
+        Please provide the information below to help us evaluate and implement support.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission checklist
+      description: Please verify these items before submitting
+      options:
+        - label: I have searched existing issues to ensure this provider isn't already requested
+          required: true
+        - label: I have checked the [LLM provider implementation guide](https://github.com/CrackingShells/Hatchling/blob/main/docs/articles/devs/contribution_guides/implementing_llm_providers.md)
+          required: true
+
+  - type: input
+    id: provider_name
+    attributes:
+      label: Provider Name
+      description: What is the name of the LLM provider?
+      placeholder: e.g., Anthropic Claude, Google Gemini, Cohere, etc.
+    validations:
+      required: true
+
+  - type: input
+    id: provider_website
+    attributes:
+      label: Provider Website/Documentation
+      description: Link to the provider's official website or API documentation
+      placeholder: https://...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: api_type
+    attributes:
+      label: API Type
+      description: What type of API does this provider offer?
+      options:
+        - REST API (HTTP-based)
+        - WebSocket API
+        - gRPC API
+        - Local/Self-hosted
+        - Other
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: features_supported
+    attributes:
+      label: Features Supported
+      description: What features does this provider support?
+      options:
+        - label: Text generation/completion
+        - label: Function/tool calling
+        - label: Streaming responses
+        - label: System messages
+        - label: Message history
+        - label: Temperature/top-p controls
+        - label: Token limits/max tokens
+        - label: Multiple models
+
+  - type: textarea
+    id: authentication
+    attributes:
+      label: Authentication Method
+      description: How does authentication work for this provider?
+      placeholder: |
+        Describe the authentication method:
+        - API key in header
+        - Bearer token
+        - OAuth
+        - No authentication required
+        - Other method
+    validations:
+      required: true
+
+  - type: textarea
+    id: models_available
+    attributes:
+      label: Available Models
+      description: What models are available from this provider?
+      placeholder: |
+        List the main models available, for example:
+        - claude-3-sonnet
+        - claude-3-haiku
+        - gemini-pro
+        - command-r-plus
+    validations:
+      required: true
+
+  - type: textarea
+    id: api_format
+    attributes:
+      label: API Request/Response Format
+      description: |
+        Provide examples of the API request and response format, or link to documentation.
+        This helps understand how to integrate with the provider.
+      placeholder: |
+        Example request format:
+        ```json
+        {
+          "model": "model-name",
+          "messages": [...],
+          "tools": [...]
+        }
+        ```
+        
+        Example response format:
+        ```json
+        {
+          "choices": [...],
+          "usage": {...}
+        }
+        ```
+      render: markdown
+
+  - type: textarea
+    id: tool_calling_support
+    attributes:
+      label: Tool Calling Support
+      description: |
+        Does this provider support function/tool calling? If so, how does it work?
+        This is important for MCP server integration.
+      placeholder: |
+        Describe tool calling support:
+        - Format for defining tools
+        - How tool calls are made
+        - Response format for tool results
+        - Any limitations or special requirements
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority/Interest Level
+      description: How important is this provider to you?
+      options:
+        - Low - Would be nice to have
+        - Medium - Would improve my workflow
+        - High - Critical for my use case
+    validations:
+      required: true
+
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use Case
+      description: Why do you need this specific provider? What advantages does it offer?
+      placeholder: |
+        Explain your use case:
+        - What makes this provider unique?
+        - What specific features or models do you need?
+        - How would this improve your Hatchling experience?
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      description: Would you be interested in helping implement this provider?
+      options:
+        - label: I would be willing to contribute to implementing this provider
+        - label: I have access to this provider's API for testing
+        - label: I would be willing to help with testing and validation
+
+  - type: textarea
+    id: additional_info
+    attributes:
+      label: Additional Information
+      description: Any other relevant information about this provider
+      placeholder: |
+        Include any additional context:
+        - Pricing/rate limits
+        - Special requirements
+        - Known limitations
+        - Links to SDKs or libraries

--- a/.github/ISSUE_TEMPLATE/mcp_server_issue.yml
+++ b/.github/ISSUE_TEMPLATE/mcp_server_issue.yml
@@ -1,0 +1,179 @@
+name: 🔧 MCP Server Issue
+description: Report issues with MCP server integration, tool discovery, or execution
+title: "[MCP]: "
+labels: ["mcp-server", "needs-triage"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting an MCP server issue! Please provide detailed information to help us diagnose the problem.
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission checklist
+      description: Please verify these items before submitting
+      options:
+        - label: I have searched existing issues to ensure this is not a duplicate
+          required: true
+        - label: I have tried disconnecting and reconnecting to the MCP server
+          required: true
+        - label: I have checked the MCP server logs for error messages
+          required: true
+
+  - type: dropdown
+    id: issue_type
+    attributes:
+      label: Issue Type
+      description: What type of MCP server issue are you experiencing?
+      options:
+        - Server Connection (cannot connect to MCP server)
+        - Tool Discovery (tools not appearing or incorrect tools)
+        - Tool Execution (tools fail to execute or return errors)
+        - Tool Chaining (issues with multiple tool calls)
+        - Citation Issues (incorrect or missing citations)
+        - Performance (slow tool execution, timeouts)
+        - Custom MCP Server (issues with self-created servers)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment Information
+      description: Please provide your system and environment details
+      placeholder: |
+        - OS: (e.g., Ubuntu 22.04, macOS 14.1, Windows 11)
+        - Hatchling version: (run `version` command in chat)
+        - Python version:
+        - Current Hatch environment: (run `hatch:env:current`)
+        - Docker setup: (yes/no, if using Docker)
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: mcp_server_info
+    attributes:
+      label: MCP Server Information
+      description: |
+        Please provide information about the MCP server(s) involved
+      placeholder: |
+        Run these commands and paste the output:
+        - `mcp:server:list`
+        - `mcp:tool:list`
+        - `mcp:health`
+        
+        For custom servers, also include:
+        - Server file path
+        - Server code (if relevant to the issue)
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Issue Description
+      description: A clear and concise description of the issue
+      placeholder: Describe what's happening with the MCP server or tools
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Detailed steps to reproduce the issue
+      placeholder: |
+        1. Connect to MCP server with '...'
+        2. Run command '...'
+        3. Try to use tool '...'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen
+      placeholder: Describe what should happen when using the MCP server or tools
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual_behavior
+    attributes:
+      label: Actual Behavior
+      description: What actually happened
+      placeholder: Describe what actually happened, including any error messages
+    validations:
+      required: true
+
+  - type: textarea
+    id: tool_details
+    attributes:
+      label: Tool Details
+      description: |
+        If the issue involves specific tools, provide details:
+      placeholder: |
+        - Tool name(s): 
+        - Tool parameters used:
+        - Expected tool output:
+        - Actual tool output:
+        - Tool execution time:
+      render: text
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs
+      description: |
+        Please include relevant log output:
+      placeholder: |
+        Include logs from:
+        - Hatchling logs: `show_logs` command or `~/.hatch/logs/hatchling.log`
+        - MCP server logs (if available)
+        - Any error messages from tool execution
+        
+        Use `set_log_level debug` for more detailed logging.
+      render: text
+
+  - type: textarea
+    id: package_info
+    attributes:
+      label: Package Information
+      description: |
+        If using Hatch packages, provide package details:
+      placeholder: |
+        - Package name and version: (run `hatch:pkg:list`)
+        - Package source: (local/registry)
+        - Package metadata: (content of hatch_metadata.json if relevant)
+      render: text
+
+  - type: textarea
+    id: workarounds
+    attributes:
+      label: Workarounds Tried
+      description: What have you tried to resolve this issue?
+      placeholder: |
+        List any workarounds or troubleshooting steps you've tried:
+        - Restarting Hatchling
+        - Recreating the environment
+        - Using different tool parameters
+        - etc.
+
+  - type: textarea
+    id: additional_context
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem
+      placeholder: |
+        Include any additional information that might be helpful:
+        - Screenshots of error messages
+        - Network connectivity issues
+        - Custom configurations
+        - Related issues or patterns


### PR DESCRIPTION
Add YAML templates under .github/ISSUE_TEMPLATE for bug reports, feature requests, LLM provider issues, MCP/server issues and documentation. Templates capture project-specific details (LLM provider/model info, MCP payloads, Docker/.env context, and test logs) to improve triage and reproducibility.