### PR TITLE
Add initial MkDocs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
+# Build documentation with Mkdocs
+mkdocs:
+   configuration: mkdocs.yml
+
+# Optionally, but recommended,
+# declare the Python requirements required to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#    install:
+#    - requirements: docs/requirements.txt

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,39 @@
+site_name: Hatchling Docs
+site_description: Documentation for the Hatchling project
+site_url: https://crackingshells.github.io/Hatchling/
+
+repo_name: CrackingShells/Hatchling
+repo_url: https://github.com/CrackingShells/Hatchling
+
+docs_dir: docs
+
+theme:
+  name: mkdocs
+
+nav:
+  - Home: index.md
+  - Users:
+      - Chat Commands: articles/users/chat_commands.md
+      - Settings: articles/users/settings.md
+      - Settings Reference: articles/users/settings_reference.md
+      - Language Support: articles/users/language_support.md
+  - Developers:
+      - Versioning: articles/devs/versioning.md
+      - Settings Architecture: articles/devs/settings_architecture.md
+      - Event System Architecture: articles/devs/event_system_architecture.md
+      - i18n Support: articles/devs/i18n_support.md
+      - Contributing: articles/devs/CONTRIBUTING.md
+  - Appendices:
+      - Glossary: articles/appendices/glossary.md
+  - Changelog: CHANGELOG.md
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - toc:
+      permalink: true
+  - tables
+  - footnotes
+  - codehilite


### PR DESCRIPTION
Introduces mkdocs.yml with site metadata, navigation structure, theme, plugins, and markdown extensions for Hatchling project documentation.