### PR TITLE
fix(deps): fixed Hatch for entrypoint retrieval

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "ollama==0.5.1",
     "openai==1.97.0",
 
-    "hatch @ git+https://github.com/CrackingShells/Hatch.git@v0.6.1"
+    "hatch @ git+https://github.com/CrackingShells/Hatch.git@v0.6.2"
 ]
 
 [project.scripts]


### PR DESCRIPTION
Hatchling suggered from not being able to connect to local servers after `Hatch-Validator` and `Hatch` failed to correctly adapt the public API.
The issue lied in failing to provide a unique name for the entry file instead of the dictionary containing the file names of the mcp server and the hatch mcp wrapper.