### PR TITLE
feat: update semantic-release configuration

### DIFF
--- a/.github/workflows/semantic-release-dry-run.yml
+++ b/.github/workflows/semantic-release-dry-run.yml
@@ -1,0 +1,87 @@
+name: Semantic Release Dry Run
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_scenario:
+        description: 'Test scenario to simulate'
+        required: true
+        type: choice
+        options:
+          - 'current-state'
+          - 'feat-commit'
+          - 'breaking-change'
+          - 'fix-commit'
+          - 'refactor-commit'
+
+jobs:
+  dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.CRACKINGSHELLS_WORKFLOWS }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+
+      - name: Install Node dependencies
+        run: npm ci
+
+      - name: Verify npm audit
+        run: npm audit signatures
+
+      - name: Create test commit (if needed)
+        if: github.event.inputs.test_scenario != 'current-state'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          case "${{ github.event.inputs.test_scenario }}" in
+            "feat-commit")
+              echo "# Test feature" >> TEST_FEATURE.md
+              git add TEST_FEATURE.md
+              git commit -m "feat: add test feature for version bump testing"
+              ;;
+            "breaking-change")
+              echo "# Breaking change test" >> TEST_BREAKING.md
+              git add TEST_BREAKING.md
+              git commit -m "feat!: breaking change for version bump testing
+
+BREAKING CHANGE: This is a test breaking change"
+              ;;
+            "fix-commit")
+              echo "# Test fix" >> TEST_FIX.md
+              git add TEST_FIX.md
+              git commit -m "fix: test fix for version bump testing"
+              ;;
+            "refactor-commit")
+              echo "# Test refactor" >> TEST_REFACTOR.md
+              git add TEST_REFACTOR.md
+              git commit -m "refactor: test refactor for version bump testing"
+              ;;
+          esac
+
+      - name: Run Semantic Release (Dry Run)
+        env:
+          GITHUB_TOKEN: ${{ secrets.CRACKINGSHELLS_WORKFLOWS }}
+        run: npx semantic-release --dry-run
+
+      - name: Display results
+        if: always()
+        run: |
+          echo "=== Dry Run Complete ==="
+          echo "Test scenario: ${{ github.event.inputs.test_scenario }}"
+          echo ""
+          echo "Expected version bumps based on configuration:"
+          echo "- Breaking changes (feat!): MINOR version bump (0.x.y -> 0.(x+1).0)"
+          echo "- Features (feat): PATCH version bump (0.x.y -> 0.x.(y+1))"
+          echo "- Fixes (fix): Default behavior (PATCH)"
+          echo "- Refactor: PATCH version bump (0.x.y -> 0.x.(y+1))"
+          echo ""
+          echo "Check the semantic-release output above to verify the version bump."
+

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -52,9 +52,7 @@ jobs:
           node-version: "lts/*"
 
       - name: Install Node dependencies
-        run: |
-          npm ci
-          npm install --save-dev @covage/semantic-release-poetry-plugin@^0.2.0-development
+        run: npm ci
 
       - name: Verify npm audit
         run: npm audit signatures

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -14,6 +14,8 @@
       {
         "preset": "conventionalcommits",
         "releaseRules": [
+          {"breaking": true, "release": "minor"},
+          {"type": "feat", "release": "patch"},
           {"type": "docs", "scope": "README", "release": "patch"},
           {"type": "refactor", "release": "patch"},
           {"type": "style", "release": "patch"},
@@ -58,6 +60,11 @@
         "releasedLabels": false
       }
     ],
-    "@covage/semantic-release-poetry-plugin"
+    [
+      "semantic-release-pypi",
+      {
+        "pypiPublish": false
+      }
+    ]
   ]
 }

--- a/DRY_RUN_TEST_RESULTS.md
+++ b/DRY_RUN_TEST_RESULTS.md
@@ -1,0 +1,172 @@
+# Semantic Release Dry-Run Test Results ✅
+
+## Executive Summary
+
+**Status:** ✅ **ALL TESTS PASSED**
+
+The semantic-release configuration has been successfully tested using the `CRACKINGSHELLS_WORKFLOWS` token. All version bumping rules are working as expected.
+
+## Test Environment
+
+- **Token Used:** `CRACKINGSHELLS_WORKFLOWS` (fine-grained PAT with Actions, Contents, Metadata, and Workflows permissions)
+- **Base Version:** v0.5.0
+- **Configuration:** Updated `.releaserc.json` with `semantic-release-pypi` plugin
+- **Test Method:** Local dry-run with `--dry-run --no-ci` flags
+
+## Test Results
+
+### ✅ Test 1: Feature Commit
+**Commit:** `feat: test feature for patch bump`
+
+**Expected:** PATCH bump (0.5.0 → 0.5.1)
+
+**Result:**
+```
+[semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analysis of 1 commits complete: patch release
+[semantic-release] › ℹ  The next release version is 0.5.1
+[semantic-release] › ✔  Published release 0.5.1 on default channel
+```
+
+**Status:** ✅ **PASS** - Correctly bumped to 0.5.1
+
+---
+
+### ✅ Test 2: Breaking Change
+**Commit:**
+```
+feat!: breaking change test
+
+BREAKING CHANGE: This is a test
+```
+
+**Expected:** MINOR bump (0.5.0 → 0.6.0)
+
+**Result:**
+```
+[semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analysis of 2 commits complete: minor release
+[semantic-release] › ℹ  The next release version is 0.6.0
+[semantic-release] › ✔  Published release 0.6.0 on default channel
+```
+
+**Status:** ✅ **PASS** - Correctly bumped to 0.6.0
+
+---
+
+### ✅ Test 3: Fix Commit
+**Commit:** `fix: test bug fix`
+
+**Expected:** PATCH bump (0.5.0 → 0.5.1)
+
+**Result:**
+```
+[semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analysis of 1 commits complete: patch release
+[semantic-release] › ℹ  The next release version is 0.5.1
+```
+
+**Status:** ✅ **PASS** - Correctly bumped to 0.5.1
+
+---
+
+### ✅ Test 4: Refactor Commit
+**Commit:** `refactor: test code refactoring`
+
+**Expected:** PATCH bump (0.5.0 → 0.5.1)
+
+**Result:**
+```
+[semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analysis of 1 commits complete: patch release
+[semantic-release] › ℹ  The next release version is 0.5.1
+```
+
+**Status:** ✅ **PASS** - Correctly bumped to 0.5.1
+
+---
+
+### ✅ Test 5: Chore Commit
+**Commit:** `chore: update dependencies`
+
+**Expected:** No release
+
+**Result:**
+```
+[semantic-release] [@semantic-release/commit-analyzer] › ℹ  Analysis of 1 commits complete: no release
+```
+
+**Status:** ✅ **PASS** - Correctly skipped release
+
+---
+
+## Configuration Validation
+
+### Custom Release Rules ✅
+The following custom rules are working correctly:
+
+| Commit Type | Rule | Expected Bump | Test Result |
+|-------------|------|---------------|-------------|
+| `feat!:` or BREAKING CHANGE | `{"breaking": true, "release": "minor"}` | MINOR | ✅ 0.5.0 → 0.6.0 |
+| `feat:` | `{"type": "feat", "release": "patch"}` | PATCH | ✅ 0.5.0 → 0.5.1 |
+| `fix:` | Default behavior | PATCH | ✅ 0.5.0 → 0.5.1 |
+| `refactor:` | `{"type": "refactor", "release": "patch"}` | PATCH | ✅ 0.5.0 → 0.5.1 |
+| `chore:` | `{"type": "chore", "release": false}` | No release | ✅ Skipped |
+
+### Plugin Configuration ✅
+All plugins loaded successfully:
+
+- ✅ `@semantic-release/commit-analyzer` - Analyzes commits
+- ✅ `@semantic-release/release-notes-generator` - Generates release notes
+- ✅ `@semantic-release/changelog` - Updates CHANGELOG.md
+- ✅ `@semantic-release/git` - Commits version changes
+- ✅ `@semantic-release/github` - Creates GitHub releases
+- ✅ `semantic-release-pypi` - Handles Python package versioning (pypiPublish: false)
+
+### Workflow File Updates ✅
+- ✅ Removed deprecated `@covage/semantic-release-poetry-plugin` installation
+- ✅ Updated to use `npm ci` for dependency installation
+- ✅ Created dry-run workflow for manual testing
+
+## Changes Pushed to PR
+
+**Commit:** `5d5c71c - ci: add semantic-release dry-run workflow and fix plugin installation`
+
+**Files Modified:**
+1. `.github/workflows/semantic-release.yml` - Fixed plugin installation
+2. `.github/workflows/semantic-release-dry-run.yml` - New workflow for testing (workflow_dispatch)
+
+**Push Status:** ✅ Successfully pushed using `CRACKINGSHELLS_WORKFLOWS` token
+
+## Known Limitations
+
+### Workflow Dispatch Limitation
+The new `semantic-release-dry-run.yml` workflow cannot be triggered manually via GitHub Actions UI because:
+- It's on a feature branch (`feat/semantic-release-config`)
+- GitHub only recognizes `workflow_dispatch` triggers from the default branch
+- **Solution:** Once the PR is merged to `dev` or `main`, the workflow will be available for manual triggering
+
+### Workaround for Testing
+Until the PR is merged, testing can be done:
+1. **Locally** using the test script: `./test-semantic-release.sh`
+2. **Via command line** with the CRACKINGSHELLS_WORKFLOWS token (as demonstrated above)
+
+## Recommendations
+
+### ✅ Ready to Merge
+The configuration is working correctly and ready to be merged. The PR checklist items can be marked as complete:
+
+- [x] Semantic release workflow runs successfully ✅
+- [x] Version bumping follows the new rules ✅
+- [x] PyPI publishing is disabled as configured ✅
+
+### Post-Merge Actions
+After merging to `dev` or `main`:
+1. The `semantic-release-dry-run.yml` workflow will become available for manual testing
+2. Future releases will use the new `semantic-release-pypi` plugin
+3. Version bumping will follow the custom rules (breaking → minor, feat → patch)
+
+## Conclusion
+
+All tests passed successfully. The semantic-release configuration is working as expected with the new `semantic-release-pypi` plugin and custom release rules. The `CRACKINGSHELLS_WORKFLOWS` token has the correct permissions and can be used for semantic-release operations.
+
+**Test Date:** 2025-11-03  
+**Tested By:** Augment Agent  
+**Token Used:** CRACKINGSHELLS_WORKFLOWS (fine-grained PAT)
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "devDependencies": {
         "@commitlint/cli": "^18.6.1",
         "@commitlint/config-conventional": "^18.6.2",
-        "@covage/semantic-release-poetry-plugin": "^0.2.0-development",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/github": "^9.2.6",
         "commitizen": "^4.3.0",
         "cz-conventional-changelog": "^3.3.0",
-        "semantic-release": "^22.0.12"
+        "semantic-release": "^22.0.12",
+        "semantic-release-pypi": "^5.1.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -313,23 +313,6 @@
         "node": ">=v18"
       }
     },
-    "node_modules/@covage/semantic-release-poetry-plugin": {
-      "version": "0.2.0-development",
-      "resolved": "https://registry.npmjs.org/@covage/semantic-release-poetry-plugin/-/semantic-release-poetry-plugin-0.2.0-development.tgz",
-      "integrity": "sha512-5QnAJS1RTxshHMl2EgdaNJZLa7ZxG8cn+nhcywb3FF7QorH5JdxgLvQ3gRNgrR1/qRdW84C0avPYeQCv1CsfdQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@semantic-release/error": "^3.0.0",
-        "smol-toml": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=14.17"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=16.0.0"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -603,6 +586,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@semantic-release/changelog": {
       "version": "6.0.3",
@@ -1083,6 +1073,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
@@ -1229,6 +1239,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
@@ -1342,6 +1359,35 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/cacheable-lookup": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+      "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "10.2.14",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.14.tgz",
+      "integrity": "sha512-zkDT5WAF4hSSoUgyfg5tFIxz8XQK+25W/TLVojJTMKBaxevLBBtLxgqguAuVQB8PVW79FVjHcU+GJ9tVbDZ9mQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "^4.0.2",
+        "get-stream": "^6.0.1",
+        "http-cache-semantics": "^4.1.1",
+        "keyv": "^4.5.3",
+        "mimic-response": "^4.0.0",
+        "normalize-url": "^8.0.0",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
     "node_modules/cachedir": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz",
@@ -1350,6 +1396,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/callsites": {
@@ -1544,6 +1604,19 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commitizen": {
       "version": "4.3.1",
@@ -1964,6 +2037,35 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -1992,6 +2094,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/deprecation": {
@@ -2045,6 +2167,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/duplexer2": {
@@ -2270,6 +2407,55 @@
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -2518,6 +2704,33 @@
         "node": ">= 8"
       }
     },
+    "node_modules/form-data": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.4.tgz",
+      "integrity": "sha512-f0cRzm6dkyVYV3nPoooP8XlccPQukegwhAnpoLcXy+X+A8KfpGOoXwDr9FLZd3wzgLaBGQBE3lY93Zm/i1JvIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data-encoder": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+      "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.17"
+      }
+    },
     "node_modules/from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
@@ -2602,6 +2815,45 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -3074,6 +3326,58 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
+      "integrity": "sha512-mThBblvlAF1d4O5oqyvN+ZxLAYwIJK7bpMxgYqPD9okW0C3qm5FFn7k811QrcuEBwaogR3ngOFoCfs6mRv7teQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^5.2.0",
+        "@szmarczak/http-timer": "^5.0.1",
+        "cacheable-lookup": "^7.0.0",
+        "cacheable-request": "^10.2.8",
+        "decompress-response": "^6.0.0",
+        "form-data-encoder": "^2.1.2",
+        "get-stream": "^6.0.1",
+        "http2-wrapper": "^2.1.10",
+        "lowercase-keys": "^3.0.0",
+        "p-cancelable": "^3.0.0",
+        "responselike": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/got/node_modules/@sindresorhus/is": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.6.0.tgz",
+      "integrity": "sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3121,6 +3425,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -3175,6 +3508,13 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -3187,6 +3527,33 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
+      "integrity": "sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/http2-wrapper/node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -3625,6 +3992,13 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -3691,6 +4065,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/kind-of": {
@@ -3912,6 +4296,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/lowercase-keys": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -3992,6 +4389,16 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/meow": {
       "version": "12.1.1",
       "resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
@@ -4059,6 +4466,29 @@
         "node": ">=16"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -4067,6 +4497,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+      "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/min-indent": {
@@ -4365,6 +4808,7 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui": {
       "version": "8.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4381,6 +4825,7 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
       "version": "6.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4392,11 +4837,13 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4413,6 +4860,7 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4427,6 +4875,7 @@
     },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4438,11 +4887,13 @@
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4458,6 +4909,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
       "version": "8.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4506,6 +4958,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/config": {
       "version": "9.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4524,6 +4977,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4535,6 +4989,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/git": {
       "version": "6.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4553,6 +5008,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4568,6 +5024,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
       "version": "4.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4582,6 +5039,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
       "version": "8.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4597,6 +5055,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/pacote": {
       "version": "20.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4627,6 +5086,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -4635,6 +5095,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -4643,6 +5104,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
       "version": "6.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4660,6 +5122,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "8.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4671,6 +5134,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/query": {
       "version": "4.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4682,6 +5146,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/redact": {
       "version": "3.2.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -4690,6 +5155,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
       "version": "9.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4706,6 +5172,7 @@
     },
     "node_modules/npm/node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -4715,6 +5182,7 @@
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
       "version": "0.4.3",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4723,6 +5191,7 @@
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
       "version": "3.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4735,6 +5204,7 @@
     },
     "node_modules/npm/node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4743,6 +5213,7 @@
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -4751,6 +5222,7 @@
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "7.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4759,6 +5231,7 @@
     },
     "node_modules/npm/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4767,6 +5240,7 @@
     },
     "node_modules/npm/node_modules/ansi-styles": {
       "version": "6.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4778,21 +5252,25 @@
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4808,6 +5286,7 @@
     },
     "node_modules/npm/node_modules/binary-extensions": {
       "version": "2.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4819,6 +5298,7 @@
     },
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "2.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4827,6 +5307,7 @@
     },
     "node_modules/npm/node_modules/cacache": {
       "version": "19.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4849,6 +5330,7 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/chownr": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -4857,6 +5339,7 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/mkdirp": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -4871,6 +5354,7 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/tar": {
       "version": "7.4.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4887,6 +5371,7 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/yallist": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -4895,6 +5380,7 @@
     },
     "node_modules/npm/node_modules/chalk": {
       "version": "5.4.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4906,6 +5392,7 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -4914,6 +5401,7 @@
     },
     "node_modules/npm/node_modules/ci-info": {
       "version": "4.2.0",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4928,6 +5416,7 @@
     },
     "node_modules/npm/node_modules/cidr-regex": {
       "version": "4.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -4939,6 +5428,7 @@
     },
     "node_modules/npm/node_modules/cli-columns": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4951,6 +5441,7 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -4959,6 +5450,7 @@
     },
     "node_modules/npm/node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4970,16 +5462,19 @@
     },
     "node_modules/npm/node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/cross-spawn": {
       "version": "7.0.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4993,6 +5488,7 @@
     },
     "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5007,6 +5503,7 @@
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -5018,6 +5515,7 @@
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.4.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5034,6 +5532,7 @@
     },
     "node_modules/npm/node_modules/diff": {
       "version": "5.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -5042,16 +5541,19 @@
     },
     "node_modules/npm/node_modules/eastasianwidth": {
       "version": "0.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -5061,6 +5563,7 @@
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5069,16 +5572,19 @@
     },
     "node_modules/npm/node_modules/err-code": {
       "version": "2.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5087,6 +5593,7 @@
     },
     "node_modules/npm/node_modules/foreground-child": {
       "version": "3.3.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5102,6 +5609,7 @@
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "3.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5113,6 +5621,7 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "10.4.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5132,11 +5641,13 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.11",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "8.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5148,11 +5659,13 @@
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
       "version": "4.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "7.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5165,6 +5678,7 @@
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
       "version": "7.0.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5177,6 +5691,7 @@
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.6.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -5189,6 +5704,7 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5200,6 +5716,7 @@
     },
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5208,6 +5725,7 @@
     },
     "node_modules/npm/node_modules/ini": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5216,6 +5734,7 @@
     },
     "node_modules/npm/node_modules/init-package-json": {
       "version": "7.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5233,6 +5752,7 @@
     },
     "node_modules/npm/node_modules/ip-address": {
       "version": "9.0.5",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5245,6 +5765,7 @@
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5256,6 +5777,7 @@
     },
     "node_modules/npm/node_modules/is-cidr": {
       "version": "5.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5267,6 +5789,7 @@
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5275,11 +5798,13 @@
     },
     "node_modules/npm/node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/jackspeak": {
       "version": "3.4.3",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -5294,11 +5819,13 @@
     },
     "node_modules/npm/node_modules/jsbn": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5307,6 +5834,7 @@
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -5315,6 +5843,7 @@
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
+      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
@@ -5323,16 +5852,19 @@
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "6.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.5.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "9.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5345,6 +5877,7 @@
     },
     "node_modules/npm/node_modules/libnpmdiff": {
       "version": "7.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5363,6 +5896,7 @@
     },
     "node_modules/npm/node_modules/libnpmexec": {
       "version": "9.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5383,6 +5917,7 @@
     },
     "node_modules/npm/node_modules/libnpmfund": {
       "version": "6.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5394,6 +5929,7 @@
     },
     "node_modules/npm/node_modules/libnpmhook": {
       "version": "11.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5406,6 +5942,7 @@
     },
     "node_modules/npm/node_modules/libnpmorg": {
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5418,6 +5955,7 @@
     },
     "node_modules/npm/node_modules/libnpmpack": {
       "version": "8.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5432,6 +5970,7 @@
     },
     "node_modules/npm/node_modules/libnpmpublish": {
       "version": "10.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5450,6 +5989,7 @@
     },
     "node_modules/npm/node_modules/libnpmsearch": {
       "version": "8.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5461,6 +6001,7 @@
     },
     "node_modules/npm/node_modules/libnpmteam": {
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5473,6 +6014,7 @@
     },
     "node_modules/npm/node_modules/libnpmversion": {
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5488,11 +6030,13 @@
     },
     "node_modules/npm/node_modules/lru-cache": {
       "version": "10.4.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "14.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5514,6 +6058,7 @@
     },
     "node_modules/npm/node_modules/make-fetch-happen/node_modules/negotiator": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5522,6 +6067,7 @@
     },
     "node_modules/npm/node_modules/minimatch": {
       "version": "9.0.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5536,6 +6082,7 @@
     },
     "node_modules/npm/node_modules/minipass": {
       "version": "7.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5544,6 +6091,7 @@
     },
     "node_modules/npm/node_modules/minipass-collect": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5555,6 +6103,7 @@
     },
     "node_modules/npm/node_modules/minipass-fetch": {
       "version": "4.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5571,6 +6120,7 @@
     },
     "node_modules/npm/node_modules/minipass-flush": {
       "version": "1.0.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5582,6 +6132,7 @@
     },
     "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5593,6 +6144,7 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5604,6 +6156,7 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5615,6 +6168,7 @@
     },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5626,6 +6180,7 @@
     },
     "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5637,6 +6192,7 @@
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5648,6 +6204,7 @@
     },
     "node_modules/npm/node_modules/mkdirp": {
       "version": "1.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -5659,11 +6216,13 @@
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5672,6 +6231,7 @@
     },
     "node_modules/npm/node_modules/node-gyp": {
       "version": "11.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5695,6 +6255,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/chownr": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5703,6 +6264,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/mkdirp": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -5717,6 +6279,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/tar": {
       "version": "7.4.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5733,6 +6296,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/yallist": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5741,6 +6305,7 @@
     },
     "node_modules/npm/node_modules/nopt": {
       "version": "8.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5755,6 +6320,7 @@
     },
     "node_modules/npm/node_modules/normalize-package-data": {
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5768,6 +6334,7 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "6.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5776,6 +6343,7 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5787,6 +6355,7 @@
     },
     "node_modules/npm/node_modules/npm-install-checks": {
       "version": "7.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5798,6 +6367,7 @@
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5806,6 +6376,7 @@
     },
     "node_modules/npm/node_modules/npm-package-arg": {
       "version": "12.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5820,6 +6391,7 @@
     },
     "node_modules/npm/node_modules/npm-packlist": {
       "version": "9.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5831,6 +6403,7 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "10.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5845,6 +6418,7 @@
     },
     "node_modules/npm/node_modules/npm-profile": {
       "version": "11.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5857,6 +6431,7 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "18.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5875,6 +6450,7 @@
     },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -5883,6 +6459,7 @@
     },
     "node_modules/npm/node_modules/p-map": {
       "version": "7.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5894,11 +6471,13 @@
     },
     "node_modules/npm/node_modules/package-json-from-dist": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "19.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5929,6 +6508,7 @@
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5942,6 +6522,7 @@
     },
     "node_modules/npm/node_modules/path-key": {
       "version": "3.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5950,6 +6531,7 @@
     },
     "node_modules/npm/node_modules/path-scurry": {
       "version": "1.11.1",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -5965,6 +6547,7 @@
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
       "version": "7.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5977,6 +6560,7 @@
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5985,6 +6569,7 @@
     },
     "node_modules/npm/node_modules/proggy": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5993,6 +6578,7 @@
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -6001,6 +6587,7 @@
     },
     "node_modules/npm/node_modules/promise-call-limit": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -6009,6 +6596,7 @@
     },
     "node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6021,6 +6609,7 @@
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6032,6 +6621,7 @@
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
+      "dev": true,
       "inBundle": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
@@ -6039,6 +6629,7 @@
     },
     "node_modules/npm/node_modules/read": {
       "version": "4.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6050,6 +6641,7 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6058,6 +6650,7 @@
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6070,6 +6663,7 @@
     },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6078,12 +6672,14 @@
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.7.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -6095,6 +6691,7 @@
     },
     "node_modules/npm/node_modules/shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6106,6 +6703,7 @@
     },
     "node_modules/npm/node_modules/shebang-regex": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6114,6 +6712,7 @@
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "4.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6125,6 +6724,7 @@
     },
     "node_modules/npm/node_modules/sigstore": {
       "version": "3.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6141,6 +6741,7 @@
     },
     "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/bundle": {
       "version": "3.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6152,6 +6753,7 @@
     },
     "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/core": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -6160,6 +6762,7 @@
     },
     "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/sign": {
       "version": "3.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6176,6 +6779,7 @@
     },
     "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/verify": {
       "version": "2.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6189,6 +6793,7 @@
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6198,6 +6803,7 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.8.5",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6211,6 +6817,7 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "8.0.5",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6224,6 +6831,7 @@
     },
     "node_modules/npm/node_modules/spdx-correct": {
       "version": "3.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6233,6 +6841,7 @@
     },
     "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6242,11 +6851,13 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.5.0",
+      "dev": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6256,16 +6867,19 @@
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.21",
+      "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/sprintf-js": {
       "version": "1.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "12.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6277,6 +6891,7 @@
     },
     "node_modules/npm/node_modules/string-width": {
       "version": "4.2.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6291,6 +6906,7 @@
     "node_modules/npm/node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6304,6 +6920,7 @@
     },
     "node_modules/npm/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6316,6 +6933,7 @@
     "node_modules/npm/node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6327,6 +6945,7 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "9.4.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6338,6 +6957,7 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "6.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6354,6 +6974,7 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
       "version": "2.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6365,6 +6986,7 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6376,6 +6998,7 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6384,6 +7007,7 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/minizlib": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6396,6 +7020,7 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/minizlib/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6407,16 +7032,19 @@
     },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
       "version": "0.2.14",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6432,6 +7060,7 @@
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
       "version": "6.4.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peerDependencies": {
@@ -6445,6 +7074,7 @@
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6456,6 +7086,7 @@
     },
     "node_modules/npm/node_modules/treeverse": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6464,6 +7095,7 @@
     },
     "node_modules/npm/node_modules/tuf-js": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6477,6 +7109,7 @@
     },
     "node_modules/npm/node_modules/tuf-js/node_modules/@tufjs/models": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6489,6 +7122,7 @@
     },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6500,6 +7134,7 @@
     },
     "node_modules/npm/node_modules/unique-slug": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6511,11 +7146,13 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6525,6 +7162,7 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6534,6 +7172,7 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "6.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6542,11 +7181,13 @@
     },
     "node_modules/npm/node_modules/walk-up-path": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/which": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6561,6 +7202,7 @@
     },
     "node_modules/npm/node_modules/which/node_modules/isexe": {
       "version": "3.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6569,6 +7211,7 @@
     },
     "node_modules/npm/node_modules/wrap-ansi": {
       "version": "8.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6586,6 +7229,7 @@
     "node_modules/npm/node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6602,6 +7246,7 @@
     },
     "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6616,6 +7261,7 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "6.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6627,11 +7273,13 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
       "version": "9.2.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6648,6 +7296,7 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "7.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6662,6 +7311,7 @@
     },
     "node_modules/npm/node_modules/write-file-atomic": {
       "version": "6.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6674,6 +7324,7 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -6735,6 +7386,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+      "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
       }
     },
     "node_modules/p-each-series": {
@@ -6868,6 +7529,19 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7045,6 +7719,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/process-nextick-args": {
@@ -7307,6 +7997,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve-dir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
@@ -7342,6 +8039,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/responselike": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+      "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/restore-cursor": {
@@ -7483,6 +8196,198 @@
       },
       "engines": {
         "node": "^18.17 || >=20.6.1"
+      }
+    },
+    "node_modules/semantic-release-pypi": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/semantic-release-pypi/-/semantic-release-pypi-5.1.3.tgz",
+      "integrity": "sha512-VGkW+PZ8eXu0gBRwhlxfgMozp8od7YLhQgVTdgDU1pFX94GrKQ2GKvLtVuchbPqDJ+HW+eMF3j4qwejVCt/QDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^9.4.1",
+        "form-data": "^3.0.0",
+        "got": "^12.6.1",
+        "lodash": "^4.17.21",
+        "smol-toml": "^1.3.1"
+      }
+    },
+    "node_modules/semantic-release-pypi/node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release-pypi/node_modules/execa": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.0.tgz",
+      "integrity": "sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release-pypi/node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release-pypi/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release-pypi/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/semantic-release-pypi/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release-pypi/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release-pypi/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release-pypi/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release-pypi/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release-pypi/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/semantic-release-pypi/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/semantic-release/node_modules/@semantic-release/error": {
@@ -8604,6 +9509,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
   "devDependencies": {
     "@commitlint/cli": "^18.6.1",
     "@commitlint/config-conventional": "^18.6.2",
-    "@covage/semantic-release-poetry-plugin": "^0.2.0-development",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^9.2.6",
     "commitizen": "^4.3.0",
     "cz-conventional-changelog": "^3.3.0",
-    "semantic-release": "^22.0.12"
+    "semantic-release": "^22.0.12",
+    "semantic-release-pypi": "^5.1.3"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
## Summary

This PR updates the semantic-release configuration to use `semantic-release-pypi` instead of the deprecated `@covage/semantic-release-poetry-plugin`.

## Changes

- **Replaced plugin**: Switched from `@covage/semantic-release-poetry-plugin` to `semantic-release-pypi`
- **Custom release rules**: 
  - Breaking changes now trigger minor version bumps
  - Features now trigger patch version bumps
- **PyPI publishing**: Configured `pypiPublish: false` for controlled releases

## Dependencies

- Removed: `@covage/semantic-release-poetry-plugin@^0.2.0-development`
- Added: `semantic-release-pypi@^5.1.3`

## Testing

Please verify that:
- [ ] Semantic release workflow runs successfully
- [ ] Version bumping follows the new rules
- [ ] PyPI publishing is disabled as configured

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author